### PR TITLE
Don't mention the "upcoming" 2016 nodebots day on the front page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,6 @@ layout: layout
 <article class="events">
 
     <div class="background-container">
-        <h2>Nodebots day</h2>
-        <p>HACKmemphis and Memphis Web Workers will be putting on a Nodebots day in 2016! We're really excited about the intersection of JavaScript and hardware and are ready to make some robots bend to our will!</p>
-    </div>
-
-    <div class="background-container">
         <h2>Chat with Web Workers</h2>
         <p>The Web Workers currently utilize the #memtech community Slack. We have our own channel, but there's also plenty of folks and other topics to join in!</p>
         <a class="button" href="http://www.memphistechnology.org/blog/2015/05/19/join-memtech-on-slack-chat/" title="Chat with us on Slack">Join the Community &raquo;</a>


### PR DESCRIPTION
If there are plans for a 2018 nodebots day, could add that instead.